### PR TITLE
Enhance request insights and match explorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.DS_Store
+dist
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# TestproductSearch
-Test for Codex
+# AI Product Search Dashboard
+
+This Vite + React dashboard helps connector manufacturers manage catalog spreadsheets, process client part requests, and generate AI-assisted proposal briefs.
+
+## Features
+
+- Upload and manage multiple catalog CSV/XLSX files with check, update, delete, and activate controls.
+- Parse client bills of material and instantly highlight matched vs missing parts.
+- Download a CSV report of coverage for rapid follow up.
+- Surface duplicate requests, missing identifiers, and top catalog manufacturers and product families.
+- Customize the agent workflow that guides the OpenAI-powered sourcing assistant.
+- Generate a proposal brief through the OpenAI Responses API.
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+Create a `.env` file with your API key to enable the AI brief:
+
+```
+VITE_OPENAI_API_KEY=sk-...
+```
+
+The project is built with Vite for quick self-deployment and includes PapaParse and SheetJS for spreadsheet ingestion.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Product Search</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "testproductsearch",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "papaparse": "^5.4.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "xlsx": "^0.18.5"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "vite": "^5.2.0"
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,666 @@
+.app-shell {
+  background: radial-gradient(circle at top left, rgba(96, 72, 255, 0.25), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(255, 110, 196, 0.2), transparent 50%),
+    #0c0727;
+  min-height: 100vh;
+  color: #f7f7fb;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+  padding-bottom: 5rem;
+}
+
+.hero {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 4rem 2rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 4vw, 3.75rem);
+  font-weight: 800;
+  line-height: 1.1;
+  margin: 0;
+}
+
+.hero p {
+  max-width: 720px;
+  margin: 0;
+  font-size: 1.1rem;
+  color: rgba(247, 247, 251, 0.8);
+}
+
+.hero__badge {
+  display: inline-flex;
+  align-self: flex-start;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  font-size: 0.875rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hero__highlights {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.highlight-card {
+  padding: 1.25rem;
+  border-radius: 1.25rem;
+  background: linear-gradient(135deg, rgba(101, 82, 255, 0.3), rgba(21, 13, 60, 0.8));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.highlight-card strong {
+  font-size: 1.1rem;
+}
+
+.highlight-card__label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: rgba(247, 247, 251, 0.6);
+}
+
+.layout {
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  padding: 0 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.panel {
+  background: rgba(15, 12, 42, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.75rem;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-shadow: 0 25px 60px rgba(13, 9, 38, 0.45);
+  backdrop-filter: blur(24px);
+}
+
+.panel__header h2 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.panel__header p {
+  margin: 0.4rem 0 0;
+  color: rgba(247, 247, 251, 0.75);
+}
+
+.panel__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.panel__actions--row {
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.panel__actions--row input[type='search'] {
+  flex: 1 1 320px;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(13, 11, 36, 0.65);
+  color: inherit;
+  font-size: 0.95rem;
+}
+
+.panel__actions--row input[type='search']::placeholder {
+  color: rgba(247, 247, 251, 0.6);
+}
+
+.panel__hint {
+  font-size: 0.85rem;
+  color: rgba(247, 247, 251, 0.65);
+}
+
+.button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  background: linear-gradient(135deg, #7058ff, #a855f7);
+  color: white;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px rgba(112, 88, 255, 0.35);
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.button--secondary {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.button--ghost {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  padding-inline: 1.1rem;
+}
+
+.button--danger {
+  color: #ff8aa6;
+  border-color: rgba(255, 138, 166, 0.5);
+}
+
+.catalog-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.catalog-card {
+  background: rgba(11, 8, 33, 0.75);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.catalog-card--active {
+  border-color: rgba(160, 120, 255, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(160, 120, 255, 0.25);
+}
+
+.catalog-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.catalog-card__header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.catalog-card__header p {
+  margin: 0.25rem 0 0;
+  color: rgba(247, 247, 251, 0.7);
+}
+
+.catalog-card__actions {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.catalog-card__body {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.catalog-card__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.catalog-record {
+  background: rgba(255, 255, 255, 0.04);
+  padding: 1rem;
+  border-radius: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.catalog-record span {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(247, 247, 251, 0.6);
+}
+
+.catalog-record strong {
+  font-size: 0.95rem;
+}
+
+.catalog-card__hint {
+  margin: 0;
+  color: rgba(247, 247, 251, 0.55);
+  font-size: 0.85rem;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 2rem;
+  background: rgba(11, 8, 33, 0.6);
+  border-radius: 1.5rem;
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+  color: rgba(247, 247, 251, 0.7);
+}
+
+.stats-cards {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.stats-card {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 1.25rem;
+  padding: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.stats-card span {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: rgba(247, 247, 251, 0.6);
+}
+
+.stats-card strong {
+  font-size: 1.3rem;
+}
+
+.coverage-bar {
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  overflow: hidden;
+}
+
+.coverage-bar__fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(135deg, #70f, #60c9ff);
+  transition: width 0.4s ease;
+}
+
+.insight-grid {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.insight-card {
+  background: rgba(15, 12, 45, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 1.5rem;
+  padding: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.insight-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.insight-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.insight-list li {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 1rem;
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.insight-list span {
+  color: rgba(247, 247, 251, 0.65);
+  font-size: 0.8rem;
+}
+
+.insight-card__footer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.insight-card__footer > span {
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(247, 247, 251, 0.55);
+}
+
+.insight-card__footer ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.insight-card__footer li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.9rem;
+  color: rgba(247, 247, 251, 0.75);
+}
+
+.insight-columns {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.insight-columns ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.insight-columns li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.9rem;
+  color: rgba(247, 247, 251, 0.8);
+}
+
+.insight-columns strong {
+  font-weight: 600;
+}
+
+.insight-label {
+  display: block;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  color: rgba(247, 247, 251, 0.55);
+  margin-bottom: 0.5rem;
+}
+
+.split-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.panel-subcard {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 220px;
+}
+
+.match-list,
+.missing-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.match-list li,
+.missing-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: rgba(0, 0, 0, 0.15);
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.match-table__wrapper {
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 1.5rem;
+  background: rgba(11, 8, 33, 0.65);
+  overflow: hidden;
+}
+
+.match-table__scroll {
+  max-height: 420px;
+  overflow: auto;
+}
+
+.match-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.match-table th,
+.match-table td {
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  text-align: left;
+}
+
+.match-table th {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  color: rgba(247, 247, 251, 0.65);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.match-table tr:last-child td {
+  border-bottom: none;
+}
+
+.match-table__note {
+  margin: 0;
+  padding: 0.75rem 1rem 1rem;
+  font-size: 0.8rem;
+  color: rgba(247, 247, 251, 0.6);
+}
+
+.match-list span,
+.missing-list span {
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.match-list p,
+.missing-list p {
+  margin: 0;
+  color: rgba(247, 247, 251, 0.7);
+  font-size: 0.85rem;
+}
+
+.empty-copy {
+  margin: 0;
+  color: rgba(247, 247, 251, 0.65);
+}
+
+.panel--ai {
+  background: linear-gradient(135deg, rgba(41, 30, 102, 0.85), rgba(17, 14, 52, 0.9));
+}
+
+.agent-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.agent-step {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: start;
+  background: rgba(0, 0, 0, 0.2);
+  padding: 1.1rem 1.4rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.agent-step__index {
+  width: 38px;
+  height: 38px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #7058ff, #a855f7);
+  font-weight: 700;
+}
+
+.agent-step input,
+.agent-step textarea {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid transparent;
+  border-radius: 0.75rem;
+  color: inherit;
+  padding: 0.75rem 1rem;
+  font-family: inherit;
+  font-size: 0.95rem;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+.agent-step textarea {
+  margin-top: 0.6rem;
+  resize: vertical;
+}
+
+.agent-step input:focus,
+.agent-step textarea:focus {
+  outline: none;
+  border: 1px solid rgba(160, 120, 255, 0.6);
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.alert {
+  padding: 1rem 1.2rem;
+  border-radius: 1rem;
+  font-size: 0.95rem;
+  background: rgba(255, 196, 0, 0.12);
+  border: 1px solid rgba(255, 196, 0, 0.25);
+}
+
+.alert--error {
+  background: rgba(255, 138, 166, 0.2);
+  border-color: rgba(255, 138, 166, 0.4);
+}
+
+.ai-brief {
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  line-height: 1.6;
+}
+
+.ai-brief p {
+  margin: 0;
+  color: rgba(247, 247, 251, 0.9);
+}
+
+.ai-placeholder {
+  text-align: center;
+  background: rgba(0, 0, 0, 0.2);
+  padding: 2.5rem 2rem;
+  border-radius: 1.5rem;
+  border: 1px dashed rgba(255, 255, 255, 0.15);
+  color: rgba(247, 247, 251, 0.75);
+}
+
+.footer {
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  padding: 0 2rem 4rem;
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  color: rgba(247, 247, 251, 0.75);
+}
+
+.footer h3 {
+  color: #ffffff;
+}
+
+.footer ul {
+  margin: 0.75rem 0 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.footer p {
+  margin-top: 0.75rem;
+}
+
+@media (max-width: 768px) {
+  .panel {
+    padding: 1.6rem;
+  }
+
+  .catalog-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .panel__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .panel__actions--row {
+    align-items: stretch;
+  }
+
+  .panel__actions--row input[type='search'] {
+    flex-basis: auto;
+  }
+
+  .button {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,855 @@
+import { useMemo, useRef, useState } from 'react';
+import Papa from 'papaparse';
+import * as XLSX from 'xlsx';
+import './App.css';
+
+const IDENTIFIER_KEYS = ['part number', 'part', 'sku', 'pn', 'component', 'item', 'id', 'mpn', 'manufacturer part number'];
+
+const MANUFACTURER_FIELDS = ['manufacturer', 'brand', 'maker', 'vendor'];
+const FAMILY_FIELDS = ['family', 'series', 'product family', 'product'];
+
+function sanitizeRecords(records) {
+  return records
+    .map((record) => {
+      const sanitized = {};
+      Object.entries(record).forEach(([key, value]) => {
+        if (value === undefined || value === null) return;
+        const trimmed = String(value).trim();
+        if (!trimmed) return;
+        sanitized[key.trim()] = trimmed;
+      });
+      return sanitized;
+    })
+    .filter((record) => Object.keys(record).length > 0);
+}
+
+function extractIdentifier(record) {
+  if (!record) return '';
+  const lowerMap = Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [key.toLowerCase(), value])
+  );
+
+  for (const candidate of IDENTIFIER_KEYS) {
+    if (lowerMap[candidate]) {
+      return lowerMap[candidate].toUpperCase();
+    }
+  }
+
+  const firstValue = Object.values(record)[0];
+  return firstValue ? String(firstValue).toUpperCase() : '';
+}
+
+function getFieldValue(record, fieldNames) {
+  if (!record) return '';
+  const entries = Object.entries(record);
+  for (const field of fieldNames) {
+    const lowerField = field.toLowerCase();
+    for (const [key, value] of entries) {
+      if (key.toLowerCase() === lowerField && value !== undefined && value !== null) {
+        const trimmed = String(value).trim();
+        if (trimmed) {
+          return trimmed;
+        }
+      }
+    }
+  }
+  return '';
+}
+
+async function parseFile(file) {
+  const extension = file.name.split('.').pop()?.toLowerCase();
+
+  if (extension === 'csv') {
+    return new Promise((resolve, reject) => {
+      Papa.parse(file, {
+        header: true,
+        skipEmptyLines: true,
+        complete: (results) => resolve(sanitizeRecords(results.data)),
+        error: (error) => reject(error),
+      });
+    });
+  }
+
+  if (['xls', 'xlsx'].includes(extension)) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        try {
+          const data = new Uint8Array(event.target.result);
+          const workbook = XLSX.read(data, { type: 'array' });
+          const sheetName = workbook.SheetNames[0];
+          const worksheet = workbook.Sheets[sheetName];
+          const jsonData = XLSX.utils.sheet_to_json(worksheet, { raw: false });
+          resolve(sanitizeRecords(jsonData));
+        } catch (error) {
+          reject(error);
+        }
+      };
+      reader.onerror = () => reject(new Error('Unable to read file.'));
+      reader.readAsArrayBuffer(file);
+    });
+  }
+
+  throw new Error('Unsupported file format. Upload CSV or Excel.');
+}
+
+const defaultAgentSteps = [
+  {
+    title: 'Understand requirements',
+    description:
+      'Use the uploaded request list to identify the number of unique components, quantities, and any missing specifications that could impact sourcing.',
+  },
+  {
+    title: 'Cross-check catalog',
+    description:
+      'Compare each requested connector with the active catalog. Flag legacy or end-of-life parts and highlight viable alternates.',
+  },
+  {
+    title: 'Compose proposal brief',
+    description:
+      'Summarize available inventory, lead times, and cost-saving bundles. Recommend follow-up actions for uncovered parts.',
+  },
+];
+
+function formatDate(date) {
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function App() {
+  const [catalogFiles, setCatalogFiles] = useState([]);
+  const [expandedCatalog, setExpandedCatalog] = useState(null);
+  const [activeCatalogId, setActiveCatalogId] = useState(null);
+  const [clientRecords, setClientRecords] = useState([]);
+  const [aiBrief, setAiBrief] = useState('');
+  const [aiError, setAiError] = useState('');
+  const [aiLoading, setAiLoading] = useState(false);
+  const [agentSteps, setAgentSteps] = useState(defaultAgentSteps);
+  const [matchSearch, setMatchSearch] = useState('');
+
+  const catalogUploadRef = useRef(null);
+  const updateUploadRef = useRef({});
+  const clientUploadRef = useRef(null);
+
+  const activeCatalog = useMemo(
+    () => catalogFiles.find((file) => file.id === activeCatalogId) || null,
+    [catalogFiles, activeCatalogId]
+  );
+
+  const matchResult = useMemo(() => {
+    if (!activeCatalog || clientRecords.length === 0) {
+      return {
+        found: [],
+        missing: [],
+      };
+    }
+
+    const catalogIndex = new Map();
+    activeCatalog.records.forEach((record) => {
+      const identifier = extractIdentifier(record);
+      if (identifier) {
+        catalogIndex.set(identifier, record);
+      }
+    });
+
+    const found = [];
+    const missing = [];
+
+    clientRecords.forEach((record) => {
+      const identifier = extractIdentifier(record);
+      if (!identifier) {
+        missing.push({ record, reason: 'No identifier detected' });
+        return;
+      }
+
+      if (catalogIndex.has(identifier)) {
+        found.push({
+          requested: record,
+          catalog: catalogIndex.get(identifier),
+        });
+      } else {
+        missing.push({ record, reason: 'Not present in catalog' });
+      }
+    });
+
+    return { found, missing };
+  }, [activeCatalog, clientRecords]);
+
+  const matchStats = useMemo(() => {
+    const total = clientRecords.length;
+    const found = matchResult.found.length;
+    const missing = matchResult.missing.length;
+    const coverage = total ? Math.round((found / total) * 100) : 0;
+    return { total, found, missing, coverage };
+  }, [clientRecords.length, matchResult]);
+
+  const requestInsights = useMemo(() => {
+    if (!clientRecords.length) {
+      return {
+        uniqueCount: 0,
+        duplicateCount: 0,
+        unidentifiedCount: 0,
+        duplicates: [],
+      };
+    }
+
+    const identifierCounts = new Map();
+    const duplicateMap = new Map();
+    let unidentifiedCount = 0;
+
+    clientRecords.forEach((record, index) => {
+      const identifier = extractIdentifier(record);
+      const key = identifier || `row-${index}`;
+      if (!identifier) {
+        unidentifiedCount += 1;
+      }
+      const current = identifierCounts.get(key) ?? 0;
+      identifierCounts.set(key, current + 1);
+      if (current >= 1) {
+        duplicateMap.set(key, {
+          identifier: identifier || `Unidentified row ${index + 1}`,
+          occurrences: current + 1,
+        });
+      }
+    });
+
+    const duplicates = Array.from(duplicateMap.values()).sort((a, b) => b.occurrences - a.occurrences);
+
+    return {
+      uniqueCount: identifierCounts.size,
+      duplicateCount: clientRecords.length - identifierCounts.size,
+      unidentifiedCount,
+      duplicates,
+    };
+  }, [clientRecords]);
+
+  const topManufacturers = useMemo(() => {
+    if (!matchResult.found.length) return [];
+    const counts = new Map();
+    matchResult.found.forEach(({ catalog }) => {
+      const manufacturer = getFieldValue(catalog, MANUFACTURER_FIELDS) || 'Unspecified manufacturer';
+      counts.set(manufacturer, (counts.get(manufacturer) ?? 0) + 1);
+    });
+    return Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3)
+      .map(([name, count]) => ({
+        name,
+        count,
+        percentage: Math.round((count / matchResult.found.length) * 100),
+      }));
+  }, [matchResult.found]);
+
+  const topFamilies = useMemo(() => {
+    if (!matchResult.found.length) return [];
+    const counts = new Map();
+    matchResult.found.forEach(({ catalog }) => {
+      const family = getFieldValue(catalog, FAMILY_FIELDS) || 'General catalog';
+      counts.set(family, (counts.get(family) ?? 0) + 1);
+    });
+    return Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3)
+      .map(([name, count]) => ({
+        name,
+        count,
+        percentage: Math.round((count / matchResult.found.length) * 100),
+      }));
+  }, [matchResult.found]);
+
+  const filteredMatches = useMemo(() => {
+    const query = matchSearch.trim().toLowerCase();
+    if (!query) return matchResult.found;
+    return matchResult.found.filter((item) => {
+      const identifier = extractIdentifier(item.requested).toLowerCase();
+      const catalogValues = Object.values(item.catalog)
+        .filter((value) => value !== undefined && value !== null)
+        .map((value) => String(value).toLowerCase());
+      if (identifier.includes(query)) return true;
+      return catalogValues.some((value) => value.includes(query));
+    });
+  }, [matchResult.found, matchSearch]);
+
+  const handleCatalogUpload = async (event) => {
+    const files = Array.from(event.target.files || []);
+    if (!files.length) return;
+
+    const uploads = await Promise.all(
+      files.map(async (file) => {
+        const records = await parseFile(file);
+        return {
+          id: crypto.randomUUID(),
+          name: file.name,
+          records,
+          uploadedAt: new Date(),
+        };
+      })
+    );
+
+    setCatalogFiles((prev) => [...uploads, ...prev]);
+    if (!activeCatalogId && uploads.length > 0) {
+      setActiveCatalogId(uploads[0].id);
+    }
+
+    if (catalogUploadRef.current) {
+      catalogUploadRef.current.value = '';
+    }
+  };
+
+  const handleCatalogReplace = async (file, catalogId) => {
+    const records = await parseFile(file);
+    setCatalogFiles((prev) =>
+      prev.map((entry) =>
+        entry.id === catalogId
+          ? { ...entry, name: file.name, records, uploadedAt: new Date() }
+          : entry
+      )
+    );
+  };
+
+  const handleClientUpload = async (event) => {
+    const files = Array.from(event.target.files || []);
+    if (!files.length) return;
+
+    const combinedRecords = [];
+
+    for (const file of files) {
+      const records = await parseFile(file);
+      combinedRecords.push(...records);
+    }
+
+    setClientRecords(combinedRecords);
+    if (clientUploadRef.current) {
+      clientUploadRef.current.value = '';
+    }
+  };
+
+  const downloadReport = () => {
+    const header = ['Requested Part', 'Status', 'Catalog Match'];
+    const rows = clientRecords.map((record) => {
+      const identifier = extractIdentifier(record);
+      const foundEntry = matchResult.found.find(
+        (item) => extractIdentifier(item.requested) === identifier
+      );
+      const status = foundEntry ? 'Available' : 'Missing';
+      const match = foundEntry ? JSON.stringify(foundEntry.catalog) : '';
+      return [identifier, status, match];
+    });
+
+    const csvContent = [header, ...rows]
+      .map((row) => row.map((cell) => `"${cell ?? ''}"`).join(','))
+      .join('\n');
+
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', 'product-search-report.csv');
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const runAiBrief = async () => {
+    setAiError('');
+    setAiLoading(true);
+
+    if (!activeCatalog) {
+      setAiError('Select an active catalog before requesting an AI brief.');
+      setAiLoading(false);
+      return;
+    }
+
+    if (!clientRecords.length) {
+      setAiError('Upload a client component list before requesting an AI brief.');
+      setAiLoading(false);
+      return;
+    }
+
+    const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
+    if (!apiKey) {
+      setAiError('Set VITE_OPENAI_API_KEY in your environment to enable AI analysis.');
+      setAiLoading(false);
+      return;
+    }
+
+    const systemPrompt = `You are an AI sourcing specialist for an electronics connector manufacturer. \n` +
+      `Combine catalog intelligence with the requested part list to produce a short, actionable brief. \n` +
+      `Highlight coverage percentage, list top available matches with advantages, and recommend next actions for missing parts.`;
+
+    try {
+      const response = await fetch('https://api.openai.com/v1/responses', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-4o-mini',
+          reasoning: { effort: 'medium' },
+          input: [
+            {
+              role: 'system',
+              content: systemPrompt,
+            },
+            {
+              role: 'user',
+              content: `Catalog sample: ${JSON.stringify(activeCatalog.records.slice(0, 10))}. \n` +
+                `Client request sample: ${JSON.stringify(clientRecords.slice(0, 10))}. \n` +
+                `Coverage: ${matchStats.coverage}% with ${matchStats.found} of ${matchStats.total} components matched. \n` +
+                `Missing identifiers: ${matchResult.missing
+                  .slice(0, 10)
+                  .map((item) => extractIdentifier(item.record) || 'Unidentified')
+                  .join(', ')}`,
+            },
+          ],
+        }),
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error?.message || 'Failed to generate AI brief.');
+      }
+
+      const textOutput =
+        data.output_text ||
+        data.choices?.[0]?.message?.content
+          ?.map((chunk) => chunk.text)
+          .join('') ||
+        '';
+
+      setAiBrief(textOutput);
+    } catch (error) {
+      setAiError(error.message);
+    } finally {
+      setAiLoading(false);
+    }
+  };
+
+  const handleAgentStepEdit = (index, field, value) => {
+    setAgentSteps((prev) =>
+      prev.map((step, idx) => (idx === index ? { ...step, [field]: value } : step))
+    );
+  };
+
+  return (
+    <div className="app-shell">
+      <header className="hero">
+        <div className="hero__badge">AI Product Search</div>
+        <h1>
+          AI-Powered Product Search<br />
+          for Accurate Connector Proposals
+        </h1>
+        <p>
+          Upload client demand lists, sync the latest catalog intelligence, and let the
+          AI sourcing agent craft actionable proposals in minutes.
+        </p>
+        <div className="hero__highlights">
+          <div className="highlight-card">
+            <span className="highlight-card__label">Key Result</span>
+            <strong>95% search time eliminated</strong>
+          </div>
+          <div className="highlight-card">
+            <span className="highlight-card__label">AI Insight</span>
+            <strong>Instant bill-of-material scans</strong>
+          </div>
+          <div className="highlight-card">
+            <span className="highlight-card__label">Smart Response</span>
+            <strong>Guided proposals & alternates</strong>
+          </div>
+        </div>
+      </header>
+
+      <main className="layout">
+        <section className="panel">
+          <div className="panel__header">
+            <h2>Catalog Management</h2>
+            <p>Upload the latest product catalog spreadsheets and keep every revision in sync.</p>
+          </div>
+          <div className="panel__actions">
+            <button className="button" onClick={() => catalogUploadRef.current?.click()}>
+              Upload catalog files
+            </button>
+            <input
+              ref={catalogUploadRef}
+              type="file"
+              accept=".csv,.xls,.xlsx"
+              multiple
+              hidden
+              onChange={handleCatalogUpload}
+            />
+          </div>
+          <div className="catalog-list">
+            {catalogFiles.length === 0 && (
+              <div className="empty-state">
+                <h3>No catalogs uploaded</h3>
+                <p>Drop in your master connector database to begin matching requests.</p>
+              </div>
+            )}
+            {catalogFiles.map((file) => {
+              const isActive = file.id === activeCatalogId;
+              const isExpanded = expandedCatalog === file.id;
+              return (
+                <article key={file.id} className={`catalog-card ${isActive ? 'catalog-card--active' : ''}`}>
+                  <header className="catalog-card__header">
+                    <div>
+                      <h3>{file.name}</h3>
+                      <p>{file.records.length} parts • Updated {formatDate(file.uploadedAt)}</p>
+                    </div>
+                    <div className="catalog-card__actions">
+                      <button className="button button--ghost" onClick={() => setExpandedCatalog(isExpanded ? null : file.id)}>
+                        {isExpanded ? 'Hide' : 'Check'}
+                      </button>
+                      <button className="button button--ghost" onClick={() => setActiveCatalogId(file.id)}>
+                        {isActive ? 'Active' : 'Activate'}
+                      </button>
+                      <button
+                        className="button button--ghost"
+                        onClick={() => updateUploadRef.current[file.id]?.click()}
+                      >
+                        Update
+                      </button>
+                      <input
+                        ref={(el) => {
+                          updateUploadRef.current[file.id] = el;
+                        }}
+                        type="file"
+                        accept=".csv,.xls,.xlsx"
+                        hidden
+                        onChange={(event) => {
+                          const replacement = event.target.files?.[0];
+                          if (replacement) {
+                            handleCatalogReplace(replacement, file.id);
+                            event.target.value = '';
+                          }
+                        }}
+                      />
+                      <button
+                        className="button button--ghost button--danger"
+                        onClick={() => {
+                          setCatalogFiles((prev) => prev.filter((entry) => entry.id !== file.id));
+                          if (activeCatalogId === file.id) {
+                            setActiveCatalogId(null);
+                          }
+                        }}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </header>
+                  {isExpanded && (
+                    <div className="catalog-card__body">
+                      <div className="catalog-card__grid">
+                        {file.records.slice(0, 5).map((record, index) => (
+                          <div key={index} className="catalog-record">
+                            {Object.entries(record).map(([key, value]) => (
+                              <div key={key}>
+                                <span>{key}</span>
+                                <strong>{value}</strong>
+                              </div>
+                            ))}
+                          </div>
+                        ))}
+                      </div>
+                      <p className="catalog-card__hint">
+                        Showing a sample of {Math.min(file.records.length, 5)} of {file.records.length} records.
+                      </p>
+                    </div>
+                  )}
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="panel">
+          <div className="panel__header">
+            <h2>Client Request Intake</h2>
+            <p>Import the bill of materials or requested connector list from customers.</p>
+          </div>
+          <div className="panel__actions">
+            <button className="button" onClick={() => clientUploadRef.current?.click()}>
+              Upload request list
+            </button>
+            <input
+              ref={clientUploadRef}
+              type="file"
+              accept=".csv,.xls,.xlsx"
+              multiple
+              hidden
+              onChange={handleClientUpload}
+            />
+            <button className="button button--secondary" onClick={downloadReport} disabled={!clientRecords.length}>
+              Download matched report
+            </button>
+          </div>
+          <div className="stats-cards">
+            <div className="stats-card">
+              <span>Total components</span>
+              <strong>{matchStats.total}</strong>
+            </div>
+            <div className="stats-card">
+              <span>Matched</span>
+              <strong>{matchStats.found}</strong>
+            </div>
+            <div className="stats-card">
+              <span>Missing</span>
+              <strong>{matchStats.missing}</strong>
+            </div>
+            <div className="stats-card">
+              <span>Coverage</span>
+              <strong>{matchStats.coverage}%</strong>
+              <div className="coverage-bar">
+                <div className="coverage-bar__fill" style={{ width: `${matchStats.coverage}%` }} />
+              </div>
+            </div>
+          </div>
+          <div className="insight-grid">
+            <div className="insight-card">
+              <h3>Request health</h3>
+              <ul className="insight-list">
+                <li>
+                  <strong>{requestInsights.uniqueCount}</strong>
+                  <span>Unique identifiers</span>
+                </li>
+                <li>
+                  <strong>{requestInsights.duplicateCount}</strong>
+                  <span>Duplicates detected</span>
+                </li>
+                <li>
+                  <strong>{requestInsights.unidentifiedCount}</strong>
+                  <span>Missing identifiers</span>
+                </li>
+              </ul>
+              {requestInsights.duplicates.length > 0 && (
+                <div className="insight-card__footer">
+                  <span>Top duplicates</span>
+                  <ul>
+                    {requestInsights.duplicates.slice(0, 3).map((entry, index) => (
+                      <li key={index}>
+                        <strong>{entry.identifier}</strong>
+                        <span>{entry.occurrences} requests</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+            <div className="insight-card">
+              <h3>Catalog matches</h3>
+              {matchResult.found.length === 0 ? (
+                <p className="empty-copy">Upload data to surface manufacturer and family insights.</p>
+              ) : (
+                <div className="insight-columns">
+                  <div>
+                    <span className="insight-label">Top manufacturers</span>
+                    <ul>
+                      {topManufacturers.map((entry, index) => (
+                        <li key={index}>
+                          <strong>{entry.name}</strong>
+                          <span>{entry.count} matches • {entry.percentage}%</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div>
+                    <span className="insight-label">Top product families</span>
+                    <ul>
+                      {topFamilies.map((entry, index) => (
+                        <li key={index}>
+                          <strong>{entry.name}</strong>
+                          <span>{entry.count} matches • {entry.percentage}%</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="split-grid">
+            <div className="panel-subcard">
+              <h3>Available matches</h3>
+              {matchResult.found.length === 0 ? (
+                <p className="empty-copy">Matches will appear here once a catalog and request list are uploaded.</p>
+              ) : (
+                <ul className="match-list">
+                  {matchResult.found.slice(0, 6).map((item, index) => (
+                    <li key={index}>
+                      <div>
+                        <span>{extractIdentifier(item.requested)}</span>
+                        <strong>{item.catalog.Description || item.catalog.description || 'Catalog match'}</strong>
+                      </div>
+                      <p>
+                        {Object.entries(item.catalog)
+                          .slice(0, 3)
+                          .map(([key, value]) => `${key}: ${value}`)
+                          .join(' • ')}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+            <div className="panel-subcard">
+              <h3>Missing or alternate required</h3>
+              {matchResult.missing.length === 0 ? (
+                <p className="empty-copy">No gaps detected. Great job!</p>
+              ) : (
+                <ul className="missing-list">
+                  {matchResult.missing.slice(0, 6).map((item, index) => (
+                    <li key={index}>
+                      <span>{extractIdentifier(item.record) || 'Unidentified part'}</span>
+                      <p>{item.reason}</p>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section className="panel">
+          <div className="panel__header">
+            <h2>Match Explorer</h2>
+            <p>Filter the merged catalog intelligence to inspect the exact records backing each match.</p>
+          </div>
+          <div className="panel__actions panel__actions--row">
+            <input
+              type="search"
+              value={matchSearch}
+              onChange={(event) => setMatchSearch(event.target.value)}
+              placeholder="Search matched parts, manufacturers, or specs"
+            />
+            <span className="panel__hint">
+              Showing {filteredMatches.length} of {matchResult.found.length} matches
+            </span>
+          </div>
+          <div className="match-table__wrapper">
+            {matchResult.found.length === 0 ? (
+              <div className="ai-placeholder">
+                <h3>No matches available</h3>
+                <p>Upload at least one catalog and client request list to explore a consolidated view.</p>
+              </div>
+            ) : (
+              <div className="match-table__scroll">
+                <table className="match-table">
+                  <thead>
+                    <tr>
+                      <th>Requested identifier</th>
+                      <th>Manufacturer</th>
+                      <th>Family</th>
+                      <th>Key specifications</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filteredMatches.slice(0, 20).map((item, index) => {
+                      const manufacturer = getFieldValue(item.catalog, MANUFACTURER_FIELDS) || '—';
+                      const family = getFieldValue(item.catalog, FAMILY_FIELDS) || '—';
+                      const specificationPairs = Object.entries(item.catalog)
+                        .filter(([key]) => !IDENTIFIER_KEYS.includes(key.toLowerCase()))
+                        .slice(0, 3)
+                        .map(([key, value]) => `${key}: ${value}`);
+                      return (
+                        <tr key={index}>
+                          <td>{extractIdentifier(item.requested)}</td>
+                          <td>{manufacturer}</td>
+                          <td>{family}</td>
+                          <td>{specificationPairs.join(' • ') || '—'}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+                {filteredMatches.length > 20 && (
+                  <p className="match-table__note">
+                    Showing first 20 matches. Refine the search to focus on specific components.
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="panel panel--ai">
+          <div className="panel__header">
+            <h2>Agent Playbook</h2>
+            <p>Describe how the AI agent should navigate each proposal. Tailor the steps for your sourcing team.</p>
+          </div>
+          <div className="agent-steps">
+            {agentSteps.map((step, index) => (
+              <div key={index} className="agent-step">
+                <div className="agent-step__index">{index + 1}</div>
+                <div>
+                  <input
+                    value={step.title}
+                    onChange={(event) => handleAgentStepEdit(index, 'title', event.target.value)}
+                  />
+                  <textarea
+                    value={step.description}
+                    onChange={(event) => handleAgentStepEdit(index, 'description', event.target.value)}
+                    rows={3}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="panel panel--ai">
+          <div className="panel__header">
+            <h2>AI Proposal Brief</h2>
+            <p>Send the latest numbers to OpenAI and receive a tailored sales-ready narrative.</p>
+          </div>
+          <div className="panel__actions">
+            <button className="button" onClick={runAiBrief} disabled={aiLoading}>
+              {aiLoading ? 'Generating…' : 'Generate AI brief'}
+            </button>
+          </div>
+          {aiError && <div className="alert alert--error">{aiError}</div>}
+          {aiBrief ? (
+            <article className="ai-brief">
+              {aiBrief.split('\n').map((line, index) => (
+                <p key={index}>{line}</p>
+              ))}
+            </article>
+          ) : (
+            <div className="ai-placeholder">
+              <h3>Ready for instant proposals</h3>
+              <p>
+                Connect your OpenAI key and the agent will generate a detailed, client-friendly summary with
+                coverage metrics, available alternates, and next-step recommendations.
+              </p>
+            </div>
+          )}
+        </section>
+      </main>
+
+      <footer className="footer">
+        <div>
+          <h3>Expected outcomes</h3>
+          <ul>
+            <li>95% search time eliminated across proposal teams</li>
+            <li>2x faster delivery of client-ready quotations</li>
+            <li>50% lower onboarding costs for new sales engineers</li>
+          </ul>
+        </div>
+        <div>
+          <h3>Deployment</h3>
+          <p>
+            Run <code>npm install</code> followed by <code>npm run dev</code> to start the Vite experience. Configure
+            <code> VITE_OPENAI_API_KEY</code> to unlock the AI brief capability.
+          </p>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+export default App;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -417,14 +417,21 @@ function App() {
         throw new Error(data.error?.message || 'Failed to generate AI brief.');
       }
 
-      const textOutput =
-        data.output_text ||
-        data.choices?.[0]?.message?.content
-          ?.map((chunk) => chunk.text)
-          .join('') ||
-        '';
+      let textOutput = data.output_text;
+      if (!textOutput) {
+        const messageContent = data.choices?.[0]?.message?.content;
+        if (Array.isArray(messageContent)) {
+          textOutput = messageContent
+            .map((chunk) =>
+              typeof chunk === 'string' ? chunk : chunk.text ?? ''
+            )
+            .join('');
+        } else if (typeof messageContent === 'string') {
+          textOutput = messageContent;
+        }
+      }
 
-      setAiBrief(textOutput);
+      setAiBrief(textOutput || 'No AI response generated.');
     } catch (error) {
       setAiError(error.message);
     } finally {

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,20 @@
+:root {
+  font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #f8f9ff;
+  background-color: #0c0727;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- surface request health signals including duplicate identifiers and missing entries in the intake panel
- visualize top manufacturers and product families plus searchable match explorer with manufacturer/family/spec columns
- style new insight cards and tables to fit the existing dashboard aesthetic

## Testing
- ⚠️ `npm install` *(fails: registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7d7cc5b88326bbed6ba95c45052c